### PR TITLE
miter corners for wall junctions (L, T, X, arbitrary angles)

### DIFF
--- a/addons/home_builder/src/builders/OpeningBuilder.cs
+++ b/addons/home_builder/src/builders/OpeningBuilder.cs
@@ -135,12 +135,14 @@ public class OpeningBuilder
         // ── 6. Save updated list back to metadata ─────────────────────────────
         SaveOpenings(wallBody, openings);
 
-        // ── 7. Rebuild mesh with all openings ─────────────────────────────────
-        var newMesh = WallMeshBuilder.BuildWithOpenings(
+        // ── 7. Rebuild mesh, keeping the current junction miter offsets ──────
+        var joins = SolveJoinsFor(wallBody);
+        var newMesh = WallMeshBuilder.BuildWithOpeningsAndJoins(
             wallLen,
             WallBuilder.Height,
             WallBuilder.Thickness,
-            openings
+            openings,
+            joins
         );
 
         // ── 8. Apply to MeshInstance3D ────────────────────────────────────────
@@ -153,11 +155,22 @@ public class OpeningBuilder
         UpdateCollision(wallBody, newMesh);
     }
 
+    // Re-solves junctions for the wall's parent and returns this wall's
+    // current mesh join offsets (or zeros if it has no neighbours).
+    private static WallMeshBuilder.JoinOffsets SolveJoinsFor(StaticBody3D wallBody)
+    {
+        if (wallBody.GetParent() is not Node3D parent) return default;
+        var all = WallJunctionSolver.Solve(parent);
+        return all.TryGetValue(wallBody, out var off)
+            ? WallJunctionSolver.ToMeshJoins(off)
+            : default;
+    }
+
     // -------------------------------------------------------------------------
     // Metadata helpers — openings stored as a Godot Array of Dictionaries
     // -------------------------------------------------------------------------
 
-    private static List<WallMeshBuilder.Opening> LoadOpenings(StaticBody3D wall)
+    public static List<WallMeshBuilder.Opening> LoadOpenings(StaticBody3D wall)
     {
         var result = new List<WallMeshBuilder.Opening>();
 
@@ -223,8 +236,14 @@ public class OpeningBuilder
             if (child is CollisionShape3D cs) { collisionShape = cs; break; }
         }
         if (collisionShape == null) return;
+        UpdateCollisionFromMesh(collisionShape, newMesh);
+    }
 
-        var vertexList = new System.Collections.Generic.List<Vector3>();
+    public static void UpdateCollisionFromMesh(CollisionShape3D collisionShape, ArrayMesh newMesh)
+    {
+        if (collisionShape == null || newMesh == null) return;
+
+        var vertexList = new List<Vector3>();
         for (int i = 0; i < newMesh.GetSurfaceCount(); i++)
         {
             var meshData = newMesh.SurfaceGetArrays(i);

--- a/addons/home_builder/src/builders/WallBuilder.cs
+++ b/addons/home_builder/src/builders/WallBuilder.cs
@@ -1,4 +1,5 @@
 using Godot;
+using System.Collections.Generic;
 
 public class WallBuilder
 {
@@ -136,6 +137,54 @@ public class WallBuilder
         undo.AddDoMethod(wallParent,   Node.MethodName.AddChild,    body);
         undo.AddUndoMethod(wallParent, Node.MethodName.RemoveChild, body);
         undo.CommitAction(false);
+
+        // Re-solve junctions for this floor and rebuild every wall whose cap
+        // offsets changed. This is what yields clean miter corners at L, T
+        // and X junctions with arbitrary angles.
+        RebuildJunctions(wallParent);
+    }
+
+    // -------------------------------------------------------------------------
+    // Junction rebuild
+    //
+    // Recomputes miter offsets across every wall under `wallParent` and
+    // rebuilds any wall whose mesh should change. Cheap for realistic scenes
+    // (tens to hundreds of walls per floor) and avoids the need to track
+    // "dirty" neighbours incrementally.
+    // -------------------------------------------------------------------------
+
+    public static void RebuildJunctions(Node3D wallParent)
+    {
+        if (wallParent == null) return;
+
+        var offsets = WallJunctionSolver.Solve(wallParent);
+        foreach (var kv in offsets)
+            RebuildWallMesh(kv.Key, kv.Value);
+    }
+
+    private static void RebuildWallMesh(StaticBody3D wallBody, WallJunctionSolver.Offsets off)
+    {
+        float wallLen = WallHelper.GetWallLength(wallBody);
+        if (wallLen <= 0f) return;
+
+        var openings = OpeningBuilder.LoadOpenings(wallBody);
+        var joins    = WallJunctionSolver.ToMeshJoins(off);
+
+        var newMesh = WallMeshBuilder.BuildWithOpeningsAndJoins(
+            wallLen, Height, Thickness, openings, joins);
+
+        MeshInstance3D meshInstance = null;
+        CollisionShape3D collisionShape = null;
+        foreach (Node child in wallBody.GetChildren())
+        {
+            if (child is MeshInstance3D mi)  meshInstance = mi;
+            if (child is CollisionShape3D c) collisionShape = c;
+        }
+        if (meshInstance == null) return;
+
+        meshInstance.Mesh = newMesh;
+        if (collisionShape != null)
+            OpeningBuilder.UpdateCollisionFromMesh(collisionShape, newMesh);
     }
 
     // -------------------------------------------------------------------------

--- a/addons/home_builder/src/helpers/WallJunctionSolver.cs
+++ b/addons/home_builder/src/helpers/WallJunctionSolver.cs
@@ -1,0 +1,291 @@
+using Godot;
+using System.Collections.Generic;
+
+// Computes per-endpoint miter offsets for wall segments so that corners,
+// T-junctions and X-junctions meet cleanly, without gaps or overlaps, for
+// ANY pair of angles (not just 90°).
+//
+// --- Algorithm ------------------------------------------------------------
+// At every point in the world XZ plane where two or more walls converge we
+// build a "node". Each wall end-point that lies at the node contributes a
+// "half-edge" whose inward direction points from the node INTO the wall
+// body. When a wall passes straight through the node (T-junction), we add
+// two VIRTUAL half-edges that represent the two continuing halves of the
+// through-wall; these constrain the miter but themselves receive no offset.
+//
+// For every pair (a, b) of angularly adjacent half-edges (in CCW order
+// around the node) we intersect:
+//   • a's CCW-side edge line, offset by perpCCW(d_a) · thickness/2
+//   • b's CW-side edge line,  offset by -perpCCW(d_b) · thickness/2
+// The intersection M is the miter point between a and b. The parametric
+// distances s_a and s_b from the node along each half-edge's inward
+// direction give the cap offsets applied to wall a (on its CCW side) and
+// wall b (on its CW side).
+//
+// --- Local frame conventions ---------------------------------------------
+// Every wall is a StaticBody3D whose Basis.X runs from the wall's Start
+// endpoint to its End endpoint in world space. Because Basis.Z = Y × X, at
+// the Start endpoint the CCW side of the inward direction maps to local -Z,
+// and at the End endpoint it maps to local +Z. See StoreOffset below.
+//
+// --- Edge cases ----------------------------------------------------------
+//   • Two walls collinear and opposite (180°): their shared miter is
+//     parallel and at infinity — we simply leave the offset at zero on that
+//     side, so the walls continue as a straight strip.
+//   • Two walls overlapping (0°): treated the same way, skipped.
+//   • Acute corners: miter distance = thickness / (2·sin(half-angle)) can
+//     become large. The solver clamps each offset to half the wall's length.
+
+public static class WallJunctionSolver
+{
+    public struct Offsets
+    {
+        public float StartMinusZ;  // cap offset at Start on local -Z side
+        public float StartPlusZ;   // cap offset at Start on local +Z side
+        public float EndMinusZ;    // cap offset at End   on local -Z side
+        public float EndPlusZ;     // cap offset at End   on local +Z side
+    }
+
+    // Two world positions within this distance are treated as the same node.
+    private const float PosTolerance = 0.01f;
+    // A point must be at least this far from either endpoint of a wall to
+    // count as "in the middle" (T-junction detection).
+    private const float MinMidDistance = 0.02f;
+    // 2D cross products below this magnitude are treated as parallel.
+    private const float ParallelEpsilon = 1e-5f;
+
+    private enum Kind { Start, End, MidVirtual }
+
+    private class HalfEdge
+    {
+        public StaticBody3D Wall;
+        public Kind         Kind;
+        public Vector3      NodePos;
+        public Vector2      Dir;          // unit XZ inward direction
+        public float        WallLength;
+        public float        Thickness;
+    }
+
+    // -------------------------------------------------------------------------
+    // Public API
+    // -------------------------------------------------------------------------
+
+    // Solves all junctions under `wallParent` and returns the offsets each
+    // wall should use for its next mesh rebuild. Walls not present in the
+    // dictionary should be rebuilt with zero offsets.
+    public static Dictionary<StaticBody3D, Offsets> Solve(Node3D wallParent)
+    {
+        var result = new Dictionary<StaticBody3D, Offsets>();
+        if (wallParent == null) return result;
+
+        // ── Collect walls and per-wall info
+        var walls     = new List<StaticBody3D>();
+        var startPos  = new Dictionary<StaticBody3D, Vector3>();
+        var endPos    = new Dictionary<StaticBody3D, Vector3>();
+        var wallDir   = new Dictionary<StaticBody3D, Vector2>();
+        var wallLen   = new Dictionary<StaticBody3D, float>();
+
+        foreach (Node child in wallParent.GetChildren())
+        {
+            if (child is not StaticBody3D b) continue;
+            float len = WallHelper.GetWallLength(b);
+            if (len <= 0f) continue;
+
+            var tr   = b.GlobalTransform;
+            var axis = tr.Basis.X;
+            var d2   = new Vector2(axis.X, axis.Z);
+            if (d2.LengthSquared() < 1e-8f) continue;
+            d2 = d2.Normalized();
+
+            walls.Add(b);
+            startPos[b] = tr.Origin - axis * (len * 0.5f);
+            endPos[b]   = tr.Origin + axis * (len * 0.5f);
+            wallDir[b]  = d2;
+            wallLen[b]  = len;
+            result[b]   = default;
+        }
+
+        if (walls.Count == 0) return result;
+
+        // ── Build half-edges at both endpoints of every wall
+        var halfEdges = new List<HalfEdge>();
+        foreach (var w in walls)
+        {
+            halfEdges.Add(new HalfEdge
+            {
+                Wall = w, Kind = Kind.Start,
+                NodePos = startPos[w],
+                Dir = wallDir[w],                    // Start inward = +axis
+                WallLength = wallLen[w],
+                Thickness = WallBuilder.Thickness,
+            });
+            halfEdges.Add(new HalfEdge
+            {
+                Wall = w, Kind = Kind.End,
+                NodePos = endPos[w],
+                Dir = -wallDir[w],                   // End inward = -axis
+                WallLength = wallLen[w],
+                Thickness = WallBuilder.Thickness,
+            });
+        }
+
+        // ── Group half-edges into nodes by world XZ position (with tolerance)
+        var nodes = new List<List<HalfEdge>>();
+        foreach (var he in halfEdges)
+        {
+            bool placed = false;
+            foreach (var node in nodes)
+            {
+                if (CloseXZ(node[0].NodePos, he.NodePos))
+                {
+                    node.Add(he);
+                    placed = true; break;
+                }
+            }
+            if (!placed) nodes.Add(new List<HalfEdge> { he });
+        }
+
+        // ── Detect T-junctions: an endpoint sitting on another wall's
+        //    centerline (away from that other wall's endpoints). We insert
+        //    two virtual half-edges so the miter code handles the T like any
+        //    other N-way junction — but the through-wall receives no offsets.
+        foreach (var node in nodes)
+        {
+            var P = node[0].NodePos;
+            foreach (var w in walls)
+            {
+                // Skip if this wall is already terminating at this node.
+                bool alreadyHere = false;
+                foreach (var he in node)
+                    if (he.Wall == w) { alreadyHere = true; break; }
+                if (alreadyHere) continue;
+
+                var dir = wallDir[w];
+                var s   = startPos[w];
+                var rel = new Vector2(P.X - s.X, P.Z - s.Z);
+                float tAlong = rel.Dot(dir);
+                float tPerp  = rel.Dot(new Vector2(-dir.Y, dir.X));
+                if (Mathf.Abs(tPerp) > PosTolerance) continue;
+
+                float L = wallLen[w];
+                if (tAlong < MinMidDistance || tAlong > L - MinMidDistance) continue;
+
+                // Virtual half-edges in both directions along the through-wall.
+                node.Add(new HalfEdge
+                {
+                    Wall = w, Kind = Kind.MidVirtual,
+                    NodePos = P, Dir = dir,
+                    WallLength = L - tAlong,
+                    Thickness = WallBuilder.Thickness,
+                });
+                node.Add(new HalfEdge
+                {
+                    Wall = w, Kind = Kind.MidVirtual,
+                    NodePos = P, Dir = -dir,
+                    WallLength = tAlong,
+                    Thickness = WallBuilder.Thickness,
+                });
+            }
+        }
+
+        // ── Solve miters per node
+        foreach (var node in nodes)
+        {
+            if (node.Count < 2) continue;
+            node.Sort((a, b) => Mathf.Atan2(a.Dir.Y, a.Dir.X)
+                                   .CompareTo(Mathf.Atan2(b.Dir.Y, b.Dir.X)));
+
+            int n = node.Count;
+            for (int i = 0; i < n; i++)
+            {
+                var a = node[i];
+                var b = node[(i + 1) % n];
+                if (!TryMiter(a, b, out float sa, out float sb)) continue;
+
+                // Clamp so we never trim more than half the wall's length.
+                sa = Mathf.Clamp(sa, -a.WallLength * 0.5f, a.WallLength * 0.5f);
+                sb = Mathf.Clamp(sb, -b.WallLength * 0.5f, b.WallLength * 0.5f);
+
+                StoreOffset(result, a, sideCCW: true,  value: sa);
+                StoreOffset(result, b, sideCCW: false, value: sb);
+            }
+        }
+
+        return result;
+    }
+
+    // -------------------------------------------------------------------------
+    // Miter between two half-edges
+    //
+    //   line A:  P + perpCCW(d_a)·(t_a/2) + s_a · d_a
+    //   line B:  P - perpCCW(d_b)·(t_b/2) + s_b · d_b
+    //
+    // Solve:  s_a · d_a - s_b · d_b = -perpCCW(d_b)·(t_b/2) - perpCCW(d_a)·(t_a/2)
+    // -------------------------------------------------------------------------
+
+    private static bool TryMiter(HalfEdge a, HalfEdge b, out float sa, out float sb)
+    {
+        sa = 0f; sb = 0f;
+
+        Vector2 da = a.Dir;
+        Vector2 db = b.Dir;
+
+        // 2D cross product; near-zero means parallel directions (0° or 180°).
+        float cross = da.X * db.Y - da.Y * db.X;
+        if (Mathf.Abs(cross) < ParallelEpsilon) return false;
+
+        Vector2 nLa = new Vector2(-da.Y, da.X);              // perpCCW(d_a)
+        Vector2 nRb = new Vector2( db.Y, -db.X);             // -perpCCW(d_b)
+
+        Vector2 rhs = nRb * (b.Thickness * 0.5f) - nLa * (a.Thickness * 0.5f);
+
+        // [ da.x  -db.x ] [ sa ]   [ rhs.x ]
+        // [ da.y  -db.y ] [ sb ] = [ rhs.y ]
+        float det = -(da.X * db.Y - da.Y * db.X);   // = -cross, guaranteed non-zero
+        sa = (rhs.X * -db.Y - (-db.X) * rhs.Y) / det;
+        sb = (da.X  * rhs.Y -  da.Y   * rhs.X) / det;
+        return true;
+    }
+
+    private static void StoreOffset(
+        Dictionary<StaticBody3D, Offsets> result,
+        HalfEdge he, bool sideCCW, float value)
+    {
+        if (he.Kind == Kind.MidVirtual || he.Wall == null) return;
+        if (!result.TryGetValue(he.Wall, out var off)) return;
+
+        if (he.Kind == Kind.Start)
+        {
+            // At Start the inward dir is +basisX, so CCW-of-inward = local -Z.
+            if (sideCCW) off.StartMinusZ = value;
+            else         off.StartPlusZ  = value;
+        }
+        else
+        {
+            // At End the inward dir is -basisX, so CCW-of-inward = local +Z.
+            if (sideCCW) off.EndPlusZ  = value;
+            else         off.EndMinusZ = value;
+        }
+        result[he.Wall] = off;
+    }
+
+    private static bool CloseXZ(Vector3 a, Vector3 b)
+    {
+        float dx = a.X - b.X;
+        float dz = a.Z - b.Z;
+        return dx * dx + dz * dz < PosTolerance * PosTolerance;
+    }
+
+    // -------------------------------------------------------------------------
+    // Convenience: translate Solver offsets to the mesh-builder struct.
+    // -------------------------------------------------------------------------
+
+    public static WallMeshBuilder.JoinOffsets ToMeshJoins(Offsets o)
+        => new WallMeshBuilder.JoinOffsets
+        {
+            StartMinusZ = o.StartMinusZ,
+            StartPlusZ  = o.StartPlusZ,
+            EndMinusZ   = o.EndMinusZ,
+            EndPlusZ    = o.EndPlusZ,
+        };
+}

--- a/addons/home_builder/src/mesh_builders/WallMeshBuilder.cs
+++ b/addons/home_builder/src/mesh_builders/WallMeshBuilder.cs
@@ -13,6 +13,10 @@ using System.Linq;
 //   Z: -thickness/2 .. +thickness/2
 //
 // Multiple openings are supported. Openings must not overlap.
+//
+// JoinOffsets lets each of the four cap corners slide along local X to
+// produce mitered corners at L, T and X junctions (see WallJunctionSolver).
+// With zero offsets the mesh is a plain rectangular prism.
 
 public static class WallMeshBuilder
 {
@@ -21,7 +25,7 @@ public static class WallMeshBuilder
     public const int SurfaceEdges = 2;
 
     // -------------------------------------------------------------------------
-    // Public data struct — one opening
+    // Public data structs
     // -------------------------------------------------------------------------
 
     public struct Opening
@@ -37,20 +41,32 @@ public static class WallMeshBuilder
         public float LocalTop   (float hy) => BottomY - hy + Height;   // in mesh local Y
     }
 
+    // Per-endpoint cap offsets used to form clean miter joints when walls
+    // meet at a corner, T-, or X-junction. Positive values trim the cap
+    // INWARD from the nominal endpoint; negative values extend it OUTWARD.
+    // The four fields are applied in the wall's local frame:
+    //   StartMinusZ — start cap corner at local Z = -thickness/2
+    //   StartPlusZ  — start cap corner at local Z = +thickness/2
+    //   EndMinusZ   — end   cap corner at local Z = -thickness/2
+    //   EndPlusZ    — end   cap corner at local Z = +thickness/2
+    public struct JoinOffsets
+    {
+        public float StartMinusZ;
+        public float StartPlusZ;
+        public float EndMinusZ;
+        public float EndPlusZ;
+    }
+
     // -------------------------------------------------------------------------
-    // Build without openings
+    // Public API
     // -------------------------------------------------------------------------
 
     public static ArrayMesh Build(float length, float height, float thickness)
-        => BuildWithOpenings(length, height, thickness, null);
-
-    // -------------------------------------------------------------------------
-    // Legacy single-opening overload (kept for compatibility)
-    // -------------------------------------------------------------------------
+        => BuildWithOpeningsAndJoins(length, height, thickness, null, default);
 
     public static ArrayMesh BuildWithOpening(float length, float height, float thickness,
         float openingCenterX, float openingWidth, float openingBottomY, float openingHeight)
-        => BuildWithOpenings(length, height, thickness, new[]
+        => BuildWithOpeningsAndJoins(length, height, thickness, new[]
         {
             new Opening
             {
@@ -59,76 +75,104 @@ public static class WallMeshBuilder
                 BottomY = openingBottomY,
                 Height  = openingHeight,
             }
-        });
-
-    // -------------------------------------------------------------------------
-    // Main builder — N openings
-    // -------------------------------------------------------------------------
+        }, default);
 
     public static ArrayMesh BuildWithOpenings(
         float length, float height, float thickness,
         IEnumerable<Opening> openings)
+        => BuildWithOpeningsAndJoins(length, height, thickness, openings, default);
+
+    public static ArrayMesh BuildWithOpeningsAndJoins(
+        float length, float height, float thickness,
+        IEnumerable<Opening> openings,
+        JoinOffsets joins)
     {
         float hx = length    * 0.5f;
         float hy = height    * 0.5f;
         float hz = thickness * 0.5f;
 
-        // Sort openings left-to-right and convert to local Y coords once
+        joins = ClampJoins(joins, length);
+
         var ops = (openings ?? Enumerable.Empty<Opening>())
             .OrderBy(o => o.CenterX)
             .ToList();
 
+        // Per-face left/right X extents derived from the joins.
+        float xStartMZ = -hx + joins.StartMinusZ;
+        float xStartPZ = -hx + joins.StartPlusZ;
+        float xEndMZ   =  hx - joins.EndMinusZ;
+        float xEndPZ   =  hx - joins.EndPlusZ;
+
         var mesh = new ArrayMesh();
-        MeshHelper.AddSurface(mesh, BuildFaceWithOpenings(hx, hy, hz, ops, faceZ: -hz, normalZ: -1f));
-        MeshHelper.AddSurface(mesh, BuildFaceWithOpenings(hx, hy, hz, ops, faceZ:  hz, normalZ:  1f));
-        MeshHelper.AddSurface(mesh, BuildEdgesWithOpenings(hx, hy, hz, ops));
+        // Face A at z = -hz uses the -Z-side offsets.
+        MeshHelper.AddSurface(mesh, BuildFace(hx, hy, ops, xStartMZ, xEndMZ, faceZ: -hz, normalZ: -1f));
+        // Face B at z = +hz uses the +Z-side offsets.
+        MeshHelper.AddSurface(mesh, BuildFace(hx, hy, ops, xStartPZ, xEndPZ, faceZ:  hz, normalZ:  1f));
+        MeshHelper.AddSurface(mesh, BuildEdges(hx, hy, hz, ops, xStartMZ, xStartPZ, xEndMZ, xEndPZ));
         return mesh;
     }
 
+    // Prevents runaway or inverted geometry for very short walls / extreme
+    // miter angles. The solver already clamps to half-length; this is the
+    // mesh-side safety net.
+    private static JoinOffsets ClampJoins(JoinOffsets j, float length)
+    {
+        float maxEach = length * 0.49f;
+        float minEach = -length * 0.49f;
+        j.StartMinusZ = Mathf.Clamp(j.StartMinusZ, minEach, maxEach);
+        j.StartPlusZ  = Mathf.Clamp(j.StartPlusZ,  minEach, maxEach);
+        j.EndMinusZ   = Mathf.Clamp(j.EndMinusZ,   minEach, maxEach);
+        j.EndPlusZ    = Mathf.Clamp(j.EndPlusZ,    minEach, maxEach);
+
+        // Keep a tiny residual length on every side so each face quad has area.
+        const float minLen = 0.01f;
+        if (j.StartMinusZ + j.EndMinusZ > length - minLen)
+        {
+            float scale = (length - minLen) / (j.StartMinusZ + j.EndMinusZ);
+            j.StartMinusZ *= scale;
+            j.EndMinusZ   *= scale;
+        }
+        if (j.StartPlusZ + j.EndPlusZ > length - minLen)
+        {
+            float scale = (length - minLen) / (j.StartPlusZ + j.EndPlusZ);
+            j.StartPlusZ *= scale;
+            j.EndPlusZ   *= scale;
+        }
+        return j;
+    }
+
     // =========================================================================
-    // Internal helpers
+    // UV helpers — map a local X/Y position to 0..1 UV space using the wall's
+    // nominal half-extents, so the texture doesn't shift when caps are mitered.
     // =========================================================================
 
-    // AddQuad: CW winding, Godot right-handed coords.
-    //
-    //  v0 ── v1
-    //  │    ╱ │
-    //  v3 ── v2
-
-    // UV helpers — map a local X/Y position to 0..1 UV space
     private static float UvX(float x, float hx) => (x + hx) / (2f * hx);
-    private static float UvY(float y, float hy) => (hy - y) / (2f * hy);  // V=0 at top
+    private static float UvY(float y, float hy) => (hy - y) / (2f * hy);   // V=0 at top
 
-    // -------------------------------------------------------------------------
-    // One flat face (Face A at z=-hz  or  Face B at z=+hz)
-    //
-    // Strategy: slice the face into a grid of horizontal bands (above top of
-    // any opening, between openings vertically, below bottom of any opening)
-    // then for each band emit columns: left margin, gaps between openings,
-    // right margin.
-    // -------------------------------------------------------------------------
+    // =========================================================================
+    // Face at z = faceZ. leftX / rightX are THIS face's slanted cap extents.
+    // =========================================================================
 
-    private static SurfaceTool BuildFaceWithOpenings(
-        float hx, float hy, float hz,
+    private static SurfaceTool BuildFace(
+        float hx, float hy,
         List<Opening> ops,
+        float leftX, float rightX,
         float faceZ, float normalZ)
     {
         var st     = new SurfaceTool();
         var normal = new Vector3(0f, 0f, normalZ);
         st.Begin(Mesh.PrimitiveType.Triangles);
 
-        // Flip X axis for Face B so it faces outward correctly
+        // Flip X axis for Face B so it faces outward correctly.
         bool flipX = normalZ > 0f;
 
         if (ops.Count == 0)
         {
-            // Full quad
-            EmitFaceQuad(st, -hx, hx, -hy, hy, hx, hy, faceZ, normal, flipX);
+            EmitFaceQuad(st, leftX, rightX, -hy, hy, hx, hy, faceZ, normal, flipX);
             return st;
         }
 
-        // Collect the unique Y levels that openings introduce
-        // Everything is in mesh-local Y: bottom = -hy, top = +hy
+        // Collect unique Y levels introduced by openings.
         var yLevels = new SortedSet<float> { -hy, hy };
         foreach (var op in ops)
         {
@@ -137,18 +181,14 @@ public static class WallMeshBuilder
             if (oBot > -hy) yLevels.Add(oBot);
             if (oTop <  hy) yLevels.Add(oTop);
         }
-
         var yList = yLevels.ToList();
 
-        // For each horizontal band [yList[i], yList[i+1]] decide which X spans
-        // are occupied by openings and emit the solid segments.
         for (int b = 0; b < yList.Count - 1; b++)
         {
             float yBot = yList[b];
             float yTop = yList[b + 1];
             float yMid = (yBot + yTop) * 0.5f;
 
-            // Collect X ranges blocked by openings in this Y band
             var blocked = new List<(float l, float r)>();
             foreach (var op in ops)
             {
@@ -159,29 +199,27 @@ public static class WallMeshBuilder
             }
             blocked.Sort((a, b2) => a.l.CompareTo(b2.l));
 
-            // Emit solid spans between/around blocked ranges
-            float cursor = -hx;
+            float cursor = leftX;
             foreach (var (bLeft, bRight) in blocked)
             {
                 if (cursor < bLeft)
                     EmitFaceQuad(st, cursor, bLeft, yBot, yTop, hx, hy, faceZ, normal, flipX);
                 cursor = bRight;
             }
-            if (cursor < hx)
-                EmitFaceQuad(st, cursor, hx, yBot, yTop, hx, hy, faceZ, normal, flipX);
+            if (cursor < rightX)
+                EmitFaceQuad(st, cursor, rightX, yBot, yTop, hx, hy, faceZ, normal, flipX);
         }
 
         return st;
     }
 
-    // Emits one axis-aligned quad on a flat face, with UV derived from wall extent.
     private static void EmitFaceQuad(SurfaceTool st,
         float x0, float x1, float y0, float y1,
         float hx, float hy, float faceZ,
         Vector3 normal, bool flipX)
     {
-        // v0=top-left, v1=top-right, v2=bottom-right, v3=bottom-left
-        // (in Face A frame — flip v0/v1 and v2/v3 for Face B)
+        if (x1 - x0 <= 0.0001f) return;   // skip zero-width spans
+
         float lx = flipX ? x1 : x0;
         float rx = flipX ? x0 : x1;
 
@@ -198,87 +236,56 @@ public static class WallMeshBuilder
         );
     }
 
-    // -------------------------------------------------------------------------
-    // Edge surfaces (top, bottom, left, right sides + opening frames)
-    // -------------------------------------------------------------------------
+    // =========================================================================
+    // Edge surfaces: top, bottom, slanted caps, and opening frames.
+    // =========================================================================
 
-    private static SurfaceTool BuildEdgesWithOpenings(
+    private static SurfaceTool BuildEdges(
         float hx, float hy, float hz,
-        List<Opening> ops)
+        List<Opening> ops,
+        float xStartMZ, float xStartPZ, float xEndMZ, float xEndPZ)
     {
         var st = new SurfaceTool();
         st.Begin(Mesh.PrimitiveType.Triangles);
 
-        // ── Top edge (normal = +Y) ────────────────────────────────────────────
+        // ── Top (+Y): single (possibly trapezoidal) quad ──────────────────────
         MeshHelper.AddQuad(st,
-            new Vector3(-hx,  hy,  hz),
-            new Vector3( hx,  hy,  hz),
-            new Vector3( hx,  hy, -hz),
-            new Vector3(-hx,  hy, -hz),
+            new Vector3(xStartPZ,  hy,  hz),
+            new Vector3(xEndPZ,    hy,  hz),
+            new Vector3(xEndMZ,    hy, -hz),
+            new Vector3(xStartMZ,  hy, -hz),
             Vector3.Up,
-            new Vector2(0, 0), new Vector2(1, 0),
-            new Vector2(1, 1), new Vector2(0, 1)
+            new Vector2(UvX(xStartPZ, hx), 0),
+            new Vector2(UvX(xEndPZ,   hx), 0),
+            new Vector2(UvX(xEndMZ,   hx), 1),
+            new Vector2(UvX(xStartMZ, hx), 1)
         );
 
-        // ── Bottom edge (normal = -Y) — split around any ground-level openings ──
+        // ── Bottom (-Y): split around floor-reaching openings ────────────────
         {
-            // Collect X spans blocked at floor level
             var blocked = new List<(float l, float r)>();
             foreach (var op in ops)
-            {
-                if (op.LocalBottom(hy) <= -hy)   // opening reaches the floor
+                if (op.LocalBottom(hy) <= -hy)
                     blocked.Add((op.Left, op.Right));
-            }
             blocked.Sort((a, b) => a.l.CompareTo(b.l));
 
-            float cursor = -hx;
+            // Walk along X, emitting trapezoidal pieces. The left/right edges
+            // of each piece can be slanted (at a cap) or flat (at an opening).
+            float leftMZ = xStartMZ, leftPZ = xStartPZ;
             foreach (var (bLeft, bRight) in blocked)
             {
-                if (cursor < bLeft)
-                    MeshHelper.AddQuad(st,
-                        new Vector3( bLeft, -hy,  hz),
-                        new Vector3(cursor, -hy,  hz),
-                        new Vector3(cursor, -hy, -hz),
-                        new Vector3( bLeft, -hy, -hz),
-                        Vector3.Down,
-                        new Vector2(UvX(bLeft,  hx), 0), new Vector2(UvX(cursor, hx), 0),
-                        new Vector2(UvX(cursor, hx), 1), new Vector2(UvX(bLeft,  hx), 1)
-                    );
-                cursor = bRight;
+                EmitBottomQuad(st, leftMZ, leftPZ, bLeft, bLeft, hx, hy, hz);
+                leftMZ = bRight;
+                leftPZ = bRight;
             }
-            if (cursor < hx)
-                MeshHelper.AddQuad(st,
-                    new Vector3(  hx,  -hy,  hz),
-                    new Vector3(cursor, -hy,  hz),
-                    new Vector3(cursor, -hy, -hz),
-                    new Vector3(  hx,  -hy, -hz),
-                    Vector3.Down,
-                    new Vector2(UvX(hx,     hx), 0), new Vector2(UvX(cursor, hx), 0),
-                    new Vector2(UvX(cursor, hx), 1), new Vector2(UvX(hx,     hx), 1)
-                );
+            EmitBottomQuad(st, leftMZ, leftPZ, xEndMZ, xEndPZ, hx, hy, hz);
         }
 
-        // ── Left outer edge (normal = -X) ─────────────────────────────────────
-        MeshHelper.AddQuad(st,
-            new Vector3(-hx,  hy, -hz),
-            new Vector3(-hx, -hy, -hz),
-            new Vector3(-hx, -hy,  hz),
-            new Vector3(-hx,  hy,  hz),
-            Vector3.Left,
-            new Vector2(0, 0), new Vector2(0, 1),
-            new Vector2(1, 1), new Vector2(1, 0)
-        );
+        // ── Start cap (outer -X end, possibly tilted) ─────────────────────────
+        EmitStartCap(st, xStartMZ, xStartPZ, hy, hz);
 
-        // ── Right outer edge (normal = +X) ────────────────────────────────────
-        MeshHelper.AddQuad(st,
-            new Vector3( hx,  hy,  hz),
-            new Vector3( hx, -hy,  hz),
-            new Vector3( hx, -hy, -hz),
-            new Vector3( hx,  hy, -hz),
-            Vector3.Right,
-            new Vector2(0, 0), new Vector2(0, 1),
-            new Vector2(1, 1), new Vector2(1, 0)
-        );
+        // ── End cap (outer +X end, possibly tilted) ───────────────────────────
+        EmitEndCap(st, xEndMZ, xEndPZ, hy, hz);
 
         // ── Opening frames ────────────────────────────────────────────────────
         foreach (var op in ops)
@@ -288,7 +295,7 @@ public static class WallMeshBuilder
             float oBottom = op.LocalBottom(hy);
             float oTop    = op.LocalTop(hy);
 
-            // Top lintel (normal = -Y, ceiling of the opening — visible from below)
+            // Top lintel
             MeshHelper.AddQuad(st,
                 new Vector3(oRight, oTop,  hz),
                 new Vector3(oLeft,  oTop,  hz),
@@ -301,7 +308,7 @@ public static class WallMeshBuilder
                 new Vector2(UvX(oRight, hx), 1)
             );
 
-            // Sill (normal = +Y — only for windows, not floor-level doors)
+            // Sill (windows only)
             if (oBottom > -hy)
             {
                 MeshHelper.AddQuad(st,
@@ -317,10 +324,10 @@ public static class WallMeshBuilder
                 );
             }
 
-            // Left jamb (normal = +X, faces right into the opening)
+            // Left jamb
             MeshHelper.AddQuad(st,
-                new Vector3(oLeft, oTop,    hz),
-                new Vector3(oLeft, oBottom, hz),
+                new Vector3(oLeft, oTop,     hz),
+                new Vector3(oLeft, oBottom,  hz),
                 new Vector3(oLeft, oBottom, -hz),
                 new Vector3(oLeft, oTop,    -hz),
                 Vector3.Right,
@@ -330,10 +337,10 @@ public static class WallMeshBuilder
                 new Vector2(1, UvY(oTop,    hy))
             );
 
-            // Right jamb (normal = -X, faces left into the opening)
+            // Right jamb
             MeshHelper.AddQuad(st,
-                new Vector3(oRight, oBottom, hz),
-                new Vector3(oRight, oTop,    hz),
+                new Vector3(oRight, oBottom,  hz),
+                new Vector3(oRight, oTop,     hz),
                 new Vector3(oRight, oTop,    -hz),
                 new Vector3(oRight, oBottom, -hz),
                 Vector3.Left,
@@ -345,5 +352,66 @@ public static class WallMeshBuilder
         }
 
         return st;
+    }
+
+    private static void EmitBottomQuad(SurfaceTool st,
+        float leftMZ, float leftPZ, float rightMZ, float rightPZ,
+        float hx, float hy, float hz)
+    {
+        // Skip pieces with no area on either side.
+        if (rightMZ - leftMZ <= 0.0001f && rightPZ - leftPZ <= 0.0001f) return;
+
+        // Matches the winding of the original axis-aligned bottom quads.
+        MeshHelper.AddQuad(st,
+            new Vector3(rightPZ, -hy,  hz),
+            new Vector3(leftPZ,  -hy,  hz),
+            new Vector3(leftMZ,  -hy, -hz),
+            new Vector3(rightMZ, -hy, -hz),
+            Vector3.Down,
+            new Vector2(UvX(rightPZ, hx), 0),
+            new Vector2(UvX(leftPZ,  hx), 0),
+            new Vector2(UvX(leftMZ,  hx), 1),
+            new Vector2(UvX(rightMZ, hx), 1)
+        );
+    }
+
+    // Start cap: outward normal points roughly -X, tilted by the offset
+    // difference between the two sides.
+    private static void EmitStartCap(SurfaceTool st,
+        float xStartMZ, float xStartPZ, float hy, float hz)
+    {
+        var tan = new Vector3(xStartPZ - xStartMZ, 0f, 2f * hz);
+        if (tan.LengthSquared() < 1e-8f) return;
+        var normal = tan.Cross(Vector3.Up).Normalized();   // outward = away from +X wall body
+
+        MeshHelper.AddQuad(st,
+            new Vector3(xStartMZ,  hy, -hz),
+            new Vector3(xStartMZ, -hy, -hz),
+            new Vector3(xStartPZ, -hy,  hz),
+            new Vector3(xStartPZ,  hy,  hz),
+            normal,
+            new Vector2(0, 0), new Vector2(0, 1),
+            new Vector2(1, 1), new Vector2(1, 0)
+        );
+    }
+
+    // End cap: outward normal points roughly +X, tilted by the offset
+    // difference between the two sides.
+    private static void EmitEndCap(SurfaceTool st,
+        float xEndMZ, float xEndPZ, float hy, float hz)
+    {
+        var tan = new Vector3(xEndMZ - xEndPZ, 0f, -2f * hz);
+        if (tan.LengthSquared() < 1e-8f) return;
+        var normal = tan.Cross(Vector3.Up).Normalized();   // outward = away from -X wall body
+
+        MeshHelper.AddQuad(st,
+            new Vector3(xEndPZ,  hy,  hz),
+            new Vector3(xEndPZ, -hy,  hz),
+            new Vector3(xEndMZ, -hy, -hz),
+            new Vector3(xEndMZ,  hy, -hz),
+            normal,
+            new Vector2(0, 0), new Vector2(0, 1),
+            new Vector2(1, 1), new Vector2(1, 0)
+        );
     }
 }


### PR DESCRIPTION
Adds a generic junction solver that lets wall segments meet cleanly at any angle, for 2-, 3- and N-way junctions, by computing per-endpoint cap offsets that each wall's mesh uses when it rebuilds.

The solver groups wall endpoints into nodes in the XZ plane. At every node it sorts the incoming half-edges by azimuth and intersects the strip edges of each pair of angularly adjacent walls to obtain the miter point. T-junctions are modelled by injecting two virtual half-edges for the through-wall; X-junctions fall out of the same pairwise pass. The resulting four scalar offsets per wall (one for each local cap corner, at local X = +/-hx, on the +/-Z side) slide only along local X, so UVs, openings and materials keep working.

WallMeshBuilder gains BuildWithOpeningsAndJoins, which slants the outer caps and the top/bottom edge quads accordingly, while faces A and B each consume their own side's offsets so they stay watertight at the cap. WallBuilder and OpeningBuilder both run the solver after structural changes so corners rebuild without any manual bookkeeping.